### PR TITLE
✨ Prevents Deploys when a Deploy is Already in Progress

### DIFF
--- a/src/Array.Extra.test.ts
+++ b/src/Array.Extra.test.ts
@@ -1,0 +1,38 @@
+import test from "ava";
+import { any, all } from "./Array.Extra";
+
+test("any when the given predicate is true for some of the members", (t) => {
+  const gt5 = (x: number) => x > 5;
+  const numbers = [1, 2, 3, 4, 5, 6];
+
+  const actual = any(gt5)(numbers);
+
+  t.true(actual);
+});
+
+test("any when the given predicate is true for none of the members", (t) => {
+  const gt10 = (x: number) => x > 10;
+  const numbers = [1, 2, 3, 4, 5, 6];
+
+  const actual = any(gt10)(numbers);
+
+  t.false(actual);
+});
+
+test("all when the given predicate is true for some of the members", (t) => {
+  const gt5 = (x: number) => x > 5;
+  const numbers = [1, 2, 3, 4, 5, 6];
+
+  const actual = all(gt5)(numbers);
+
+  t.false(actual);
+});
+
+test("all when the given predicate is true for all of the members", (t) => {
+  const lt10 = (x: number) => x < 10;
+  const numbers = [1, 2, 3, 4, 5, 6];
+
+  const actual = all(lt10)(numbers);
+
+  t.true(actual);
+});

--- a/src/Array.Extra.ts
+++ b/src/Array.Extra.ts
@@ -1,0 +1,24 @@
+import { filter, isEmpty, isNonEmpty } from "fp-ts/lib/Array";
+import { Predicate, flow, not } from "fp-ts/lib/function";
+
+/**
+ * any :: Predicate a -> Predicate (Array a)
+ *
+ * Returns true when the given predicate is true for any number of the members of the given array.
+ */
+export const any = <A>(p: Predicate<A>): Predicate<Array<A>> =>
+  flow(
+    filter(p),
+    isNonEmpty,
+  );
+
+/**
+ * all :: Predicate a -> Predicate (Array a)
+ *
+ * Returns true when the given predicate is true for all of the members of the given array.
+ */
+export const all = <A>(p: Predicate<A>): Predicate<Array<A>> =>
+  flow(
+    filter(not(p)),
+    isEmpty,
+  );

--- a/src/Deploy/index.ts
+++ b/src/Deploy/index.ts
@@ -55,7 +55,7 @@ export interface Deploy {
  */
 export const fromBundle = (bundle: Bundle.Bundle): TaskEither<string, Deploy> =>
   flow(
-    arrayMap(Heroku.Build.create),
+    arrayMap(Heroku.Build.safelyCreate),
     arrayAp([bundle.codeshipBuild.commit_sha]),
     array.sequence(taskEither),
     taskEitherMap((builds: Array<Heroku.Build.Build>) => ({

--- a/src/Deploy/index.ts
+++ b/src/Deploy/index.ts
@@ -1,4 +1,12 @@
-import { array, map as arrayMap, ap as arrayAp } from "fp-ts/lib/Array";
+import {
+  array,
+  map as arrayMap,
+  ap as arrayAp,
+  filter,
+  sortBy,
+  reverse,
+  head,
+} from "fp-ts/lib/Array";
 import { flow } from "fp-ts/lib/function";
 import {
   TaskEither,
@@ -55,3 +63,17 @@ export const fromBundle = (bundle: Bundle.Bundle): TaskEither<string, Deploy> =>
       builds,
     })),
   )(bundle.targets);
+
+/**
+ * getBestBundle :: Array Bundle -> Option Bundle
+ *
+ * Given an array of deploy bundles, tries to get the best one to deploy.
+ * First, we remove all of the bundles that are not deployable.
+ * Then we choose the bundle with the most recent queued at timestamp on its Codeship build.
+ */
+export const getBestBundle = flow(
+  filter(Bundle.isDeployable),
+  sortBy([Bundle.byQueuedAt]),
+  reverse,
+  head,
+);

--- a/src/Heroku/Build.ts
+++ b/src/Heroku/Build.ts
@@ -86,3 +86,13 @@ export const create = (app: string) => (sha: string): Request<Build> =>
       id: "fake user",
     },
   });
+
+/**
+ * all :: String -> TaskEither String (Array Build)
+ *
+ * Returns a task of an array of the 30 recent builds for the given Heroku app.
+ */
+export const all = flow(
+  (app: string) => API.get<Array<Build>>(`/apps/${app}/builds`),
+  map((res) => res.data),
+);

--- a/src/Heroku/Build.ts
+++ b/src/Heroku/Build.ts
@@ -33,6 +33,8 @@ export interface Build {
   };
 }
 
+export const isPending = ({ status }: Build): boolean => status === "pending";
+
 interface CreateParams {
   source_blob: SourceBlob;
 }

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -6,7 +6,7 @@ export type Request<A> = TaskEither<string, A>;
 const onError = ({ config, message, response }: AxiosError) => {
   const lines: Array<string> = [];
 
-  if (config && config.url) lines.push(config.url);
+  if (config && config.url) lines.push(`${config.method} ${config.url}`);
 
   lines.push(message);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,16 +84,10 @@ const buildsToDeployBundles = (builds: Array<Codeship.Build.Build>) =>
 /**
  * getBestDeployBundle :: Array Deploy.Bundle.Bundle -> TaskEither String Deploy.Bundle.Bundle
  *
- * Given an array of deploy bundles, tries to get the best one to deploy.
- * First, we remove all of the bundles that are not deployable.
- * Then we choose the bundle with the most recent queued at timestamp on its Codeship build.
  * We return a TaskEither to keep it more consistent with the rest of the main function.
  */
 const getBestDeployBundle = flow(
-  Array.filter(Deploy.Bundle.isDeployable),
-  Array.sortBy([Deploy.Bundle.byQueuedAt]),
-  Array.reverse,
-  Array.head,
+  Deploy.getBestBundle,
   TaskEither.fromOption(constant("No deployable builds found.")),
 );
 


### PR DESCRIPTION
Most importantly, this PR introduces `Heroku.Build.safelyCreate` which is just like `Heroku.Build.create`, except that it checks to make sure there are no pending builds on the target application.

Also in this PR are: `Heroku.Build.isPending`, `Heroku.Build.all`, `Array.Extra.any`, `Array.Extra.all`, and a small improvement to Request errors to display the method of the request.