### PR TITLE
✨ Enables Multi-Target Deploys

### DIFF
--- a/src/Deploy/Bundle.ts
+++ b/src/Deploy/Bundle.ts
@@ -7,7 +7,7 @@ import * as Env from "../Env";
 import * as Github from "../Github";
 import * as Heroku from "../Heroku";
 
-const appName = Env.get("HEROKU_APP_NAME");
+const appNames = Env.getArray("HEROKU_APP_NAME");
 
 export interface Bundle {
   targets: Array<string>;
@@ -57,7 +57,7 @@ export const fromBuildAndSlug = ([build, slug]: [
   return flow(
     Github.Comparison.getComparison,
     map((comparison) => ({
-      targets: [appName],
+      targets: appNames,
       comparison,
       codeshipBuild: build,
     })),

--- a/src/Env.ts
+++ b/src/Env.ts
@@ -1,4 +1,7 @@
 require("dotenv").config();
+import { flow } from "fp-ts/lib/function";
+import { map } from "fp-ts/lib/Array";
+import { split, trim } from "./String.Extra";
 
 /**
  * get :: String -> String
@@ -13,3 +16,12 @@ export const get = (key: string): string => {
 
   throw new Error(`${key} must be set in ENV.`);
 };
+
+/**
+ * getArray :: String -> Array String
+ */
+export const getArray = flow(
+  get,
+  split(","),
+  map(trim),
+);

--- a/src/String.Extra.ts
+++ b/src/String.Extra.ts
@@ -1,0 +1,4 @@
+export const split = (seperator: string | RegExp) => (target: string) =>
+  target.split(seperator);
+
+export const trim = (target: string) => target.trim();

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { flow, constant } from "fp-ts/lib/function";
 import * as Task from "fp-ts/lib/Task";
 import * as TaskEither from "fp-ts/lib/TaskEither";
 import * as Codeship from "./Codeship";
-import { get } from "./Env";
+import { get, getArray } from "./Env";
 import * as Deploy from "./Deploy";
 import * as Heroku from "./Heroku";
 import * as Notifier from "./Notifier";
@@ -16,7 +16,7 @@ if (get("EMERGENCY_BRAKE") === "ENGAGED")
   throw new Error("🚨 EMERGENCY BRAKE ENGAGED!");
 // Please don't play with the emergency brake. It is not a toy.
 
-const appName = get("HEROKU_APP_NAME");
+const [leader, ...followers] = getArray("HEROKU_APP_NAME");
 
 /**
  * buildAndSlugPairsToDeployBundles :: Array (Tuple Codeship.Build.Build Heroku.Slug.Slug) -> TaskEither String (Array Deploy.Bundle.Bundle)
@@ -84,7 +84,7 @@ const buildsToDeployBundles = (builds: Array<Codeship.Build.Build>) =>
     Heroku.Slug.getCurrent,
     TaskEither.map((slug) => zipFill([builds, slug])),
     TaskEither.chain(buildAndSlugPairsToDeployBundles),
-  )(appName);
+  )(leader);
 
 /**
  * getBestDeployBundle :: Array Deploy.Bundle.Bundle -> TaskEither String Deploy.Bundle.Bundle


### PR DESCRIPTION
This pull request does a bit of refactoring to fully enable multi-target deploys.

Now, `HEROKU_APP_NAME` can be a comma-separated list of Heroku application names. The first name in the list will be considered the **leader** and will be the application that is looked at for determining whether a Codeship Build is ahead of the current Heroku Slug.

To make the error handling more clear, this pull request changes `Deploy.Deploy.builds` from `Array<Heroku.Build.Build>` to `Array<Either<string, Heroku.Build.Build>>`. This change allows us to have a deploy to one of the targets fail, without failing everything (since the other deploys might succeed).

At some point, we can improve the Slack Message that we send to make use of this information, or even follow-up on each of the Builds and print their statuses in Slack.