### PR TITLE
Switches from String to Actual Errors

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,8 +1,17 @@
+import { flow } from "fp-ts/lib/function";
 import { tap } from "./Function.Extra";
+
+const jsonStringify: <A>(a: A) => string = JSON.stringify;
+const consoleLog: <A>(a: A) => void = console.log.bind(console);
 
 /**
  * log :: A -> A
  *
  * Logs the given value and returns the given value unchanged.
  */
-export const log: <A>(a: A) => A = tap((a) => console.log(a));
+export const log: <A>(a: A) => A = tap(
+  flow(
+    jsonStringify,
+    consoleLog,
+  ),
+);

--- a/src/MaglevError.ts
+++ b/src/MaglevError.ts
@@ -1,0 +1,13 @@
+import { RequestError } from "./Request";
+import * as Deploy from "./Deploy";
+import * as Heroku from "./Heroku";
+
+type MaglevError =
+  | RequestError
+  | Deploy.Bundle.CreateError
+  | Deploy.Bundle.NotFoundError
+  | Heroku.Build.CreateError
+  | Heroku.Release.NotFoundError
+  | Heroku.Slug.NotFoundError;
+
+export default MaglevError;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import * as Heroku from "./Heroku";
 import * as Notifier from "./Notifier";
 import { zipFill } from "./Tuple.Extra";
 import { log } from "./Logger";
+import MaglevError from "./MaglevError";
 
 // This is the emergency brake. If it is set to "ENGAGED", it will prevent the train from running.
 if (get("EMERGENCY_BRAKE") === "ENGAGED")
@@ -93,7 +94,12 @@ const buildsToDeployBundles = (builds: Array<Codeship.Build.Build>) =>
  */
 const getBestDeployBundle = flow(
   Deploy.getBestBundle,
-  TaskEither.fromOption(constant("No deployable builds found.")),
+  TaskEither.fromOption<MaglevError>(
+    constant({
+      kind: "Deploy.Bundle.NotFoundError",
+      message: "No deployable builds found.",
+    }),
+  ),
 );
 
 /**


### PR DESCRIPTION
Now that we're plugged into DataDog, returning actual errors _should_ make the logging nicer. Also, we're converting the other logs to JSON strings!