### PR TITLE
🐛 Fixes Double Message Bug

### DIFF
--- a/src/Deploy/Bundle.ts
+++ b/src/Deploy/Bundle.ts
@@ -19,8 +19,8 @@ export interface CreateError {
   kind: "Deploy.Bundle.CreateError";
   message: string;
   stack?: string;
-  build: Codeship.Build.Build;
-  slug: Heroku.Slug.Slug;
+  codeshipBuild: Codeship.Build.Build;
+  herokuSlug?: Heroku.Slug.Slug;
 }
 
 export interface NotFoundError {
@@ -61,8 +61,8 @@ export const fromBuildAndSlug = ([build, slug]: [
       kind: "Deploy.Bundle.CreateError",
       message:
         "Cannot create a Deploy Bundle from a Heroku Slug without a commit sha.",
-      build,
-      slug,
+      codeshipBuild: build,
+      herokuSlug: slug,
     });
   }
 
@@ -71,8 +71,8 @@ export const fromBuildAndSlug = ([build, slug]: [
       kind: "Deploy.Bundle.CreateError",
       message:
         "Cannot create a Deploy Bundle from a Codeship Build without a commit sha.",
-      build,
-      slug,
+      codeshipBuild: build,
+      herokuSlug: slug,
     });
   }
 

--- a/src/Deploy/Bundle.ts
+++ b/src/Deploy/Bundle.ts
@@ -1,4 +1,3 @@
-import { isRight } from "fp-ts/lib/Either";
 import { flow } from "fp-ts/lib/function";
 import { ord, ordDate } from "fp-ts/lib/Ord";
 import { TaskEither, left, map } from "fp-ts/lib/TaskEither";

--- a/src/Heroku/Build.ts
+++ b/src/Heroku/Build.ts
@@ -1,13 +1,11 @@
 import { flow, constant, not } from "fp-ts/lib/function";
 import {
   TaskEither,
-  right,
   map,
   chain,
   fromPredicate,
 } from "fp-ts/lib/TaskEither";
 import { any } from "../Array.Extra";
-import MaglevError from "../MaglevError";
 import { Request, RequestError } from "../Request";
 import * as Github from "../Github";
 import * as API from "./API";

--- a/src/Heroku/Build.ts
+++ b/src/Heroku/Build.ts
@@ -1,9 +1,12 @@
+import { head, filter } from "fp-ts/lib/Array";
 import { flow, constant, not } from "fp-ts/lib/function";
+import { Option } from "fp-ts/lib/Option";
 import {
   TaskEither,
   map,
   chain,
   fromPredicate,
+  fromOption,
 } from "fp-ts/lib/TaskEither";
 import { any } from "../Array.Extra";
 import { Request, RequestError } from "../Request";
@@ -40,6 +43,7 @@ export interface Build {
 }
 
 export const isPending = ({ status }: Build): boolean => status === "pending";
+export const isFailed = ({ status }: Build): boolean => status === "failed";
 
 interface CreateParams {
   source_blob: SourceBlob;
@@ -73,6 +77,54 @@ export const all = flow(
   (app: string) => API.get<Array<Build>>(`/apps/${app}/builds`),
   map((res) => res.data),
 );
+
+export interface NotFoundError {
+  kind: "Heroku.Build.NotFoundError";
+  message: "No Heroku Build Found";
+  stack?: string;
+  app: string;
+}
+
+/**
+ * getMostRecent :: String -> Task String Build
+ *
+ * Returns a task of the most recent Heroku build from the given app.
+ *
+ * The /apps/:name/builds endpoint can be sorted and filtered by a given range. In this case, we
+ * want to get the most recent build, so we set the order to be descending and limit the request
+ * to maximum of 1 result.
+ *
+ * We will always get back an array of builds, even if we specify a max of 1, so we need to grab
+ * the head of the array of builds.
+ *
+ * Array.head returns an Option of whatever is in the array, in our case a build. In our program,
+ * we only want to consider this operation as successful if we actually have a build at the end,
+ * if our Option of a Build resolves to a None, we can convert that into a failing TaskEither.
+ *
+ * In any case, we are returning a TaskEither of a Build, not a TaskEither of an Option of a Build.
+ */
+export const getMostRecent = (
+  appName: string,
+): TaskEither<RequestError | NotFoundError, Build> =>
+  flow(
+    (appName: string) =>
+      API.get<Array<Build>>(
+        `/apps/${appName}/builds`,
+        "created_at; order=desc, max=1",
+      ),
+    map((res) => res.data),
+    map(filter(not(isFailed))),
+    map(head),
+    chain<RequestError | NotFoundError, Option<Build>, Build>(
+      fromOption(
+        constant({
+          kind: "Heroku.Build.NotFoundError",
+          message: "No Heroku Build Found",
+          app: appName,
+        }),
+      ),
+    ),
+  )(appName);
 
 export interface CreateError {
   kind: "Heroku.Build.CreateError";

--- a/src/MaglevError.ts
+++ b/src/MaglevError.ts
@@ -7,6 +7,7 @@ type MaglevError =
   | Deploy.Bundle.CreateError
   | Deploy.Bundle.NotFoundError
   | Heroku.Build.CreateError
+  | Heroku.Build.NotFoundError
   | Heroku.Release.NotFoundError
   | Heroku.Slug.NotFoundError;
 


### PR DESCRIPTION
Currently, to figure out what needs to be included in the next release, we look at the **current slug of the leader Heroku application**. If it takes more time for Heroku to finish doing a release than the interval on which 🚄 Maglev runs, anything released in the last batch will not yet be in the current slug.

In order to prevent those items from being shown, needlessly, again, this pull request makes it so that we are looking at the **most recent build**, instead of the current slug. The most recent build will include builds that are not yet finished, so we will not run into this double-message problem.