### PR TITLE
Looks at last 10 Heroku Builds

### DIFF
--- a/src/Heroku/Build.ts
+++ b/src/Heroku/Build.ts
@@ -110,7 +110,7 @@ export const getMostRecent = (
     (appName: string) =>
       API.get<Array<Build>>(
         `/apps/${appName}/builds`,
-        "created_at; order=desc, max=1",
+        "created_at; order=desc, max=10",
       ),
     map((res) => res.data),
     map(filter(not(isFailed))),


### PR DESCRIPTION
We were looking at only the last build and ignoring it if it failed. Now, we'll look at the last 10 builds and filter out the failures.