### PR TITLE
Stop json stringifying when logging

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,7 +1,7 @@
 import { flow } from "fp-ts/lib/function";
 import { tap } from "./Function.Extra";
 
-const jsonStringify: <A>(a: A) => string = JSON.stringify;
+// const jsonStringify: <A>(a: A) => string = JSON.stringify;
 const consoleLog: <A>(a: A) => void = console.log.bind(console);
 
 /**
@@ -11,7 +11,6 @@ const consoleLog: <A>(a: A) => void = console.log.bind(console);
  */
 export const log: <A>(a: A) => A = tap(
   flow(
-    jsonStringify,
     consoleLog,
   ),
 );


### PR DESCRIPTION
Our deploy tool isn't working, and we're not sure why because it can't properly stringify the error message. 

DD logs show `TypeError: Converting circular structure to JSON`

https://grailed-team.slack.com/archives/CHA0TUFD5/p1682354367369099