### PR TITLE
Custom stringify for circular reference

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,7 +1,25 @@
 import { flow } from "fp-ts/lib/function";
 import { tap } from "./Function.Extra";
 
-// const jsonStringify: <A>(a: A) => string = JSON.stringify;
+const jsonStringify = <A>(obj: A): string => {
+  let cache: Array<any>  = [];
+
+  let str = JSON.stringify(obj, (_key, value: any) => {
+    if (typeof value === "object" && value !== null) {
+      if (cache.indexOf(value) !== -1) {
+        // Circular reference found, discard key
+        return;
+      }
+      // Store value in our collection
+      cache.push(value);
+    }
+    return value;
+  });
+
+  cache = []; // reset the cache
+  return str;
+}
+
 const consoleLog: <A>(a: A) => void = console.log.bind(console);
 
 /**
@@ -11,6 +29,7 @@ const consoleLog: <A>(a: A) => void = console.log.bind(console);
  */
 export const log: <A>(a: A) => A = tap(
   flow(
+    jsonStringify,
     consoleLog,
   ),
 );

--- a/src/Slack/API.ts
+++ b/src/Slack/API.ts
@@ -11,7 +11,7 @@ export const post = <D, A>(url: string, data: D) =>
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,
-      "Content-type": "application/json",
+      "Content-type": "application/json; charset=utf-8",
     },
     data,
   });


### PR DESCRIPTION
We want less log noise in DD, but some Maglev errors contain circular references.

In this PR we write a custom stringify helper to remove circular references from your objects before calling JSON.stringify().

taken from: https://codedamn.com/news/javascript/how-to-fix-typeerror-converting-circular-structure-to-json-in-js

https://grailed-team.slack.com/archives/CHA0TUFD5/p1682354367369099