### PR TITLE
Escape special characters in commit messages

### DIFF
--- a/src/Notifier.ts
+++ b/src/Notifier.ts
@@ -32,9 +32,9 @@ const commitRefBlock = (commit: Commit.CommitReference) =>
 // https://api.slack.com/reference/surfaces/formatting#escaping
 const escapeCommitMessage = (message: string) =>
   message
-    .replace("&lt;", "&amp;")
-    .replace("<", "&lt;")
-    .replace(">", "&gt;");
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 
 const MAX_COMMIT_COUNT = 15;
 


### PR DESCRIPTION
## Description
We noticed this release message was malformed in Slack:
https://grailed-team.slack.com/archives/C08HQSD8CQY/p1750961470784569

Slack recommends escaping `<`, `>` and `&`, which should fix it
https://api.slack.com/reference/surfaces/formatting#escaping

## Screenshot
<img width="326" alt="Screenshot 2025-06-26 at 2 26 24 PM" src="https://github.com/user-attachments/assets/76288e80-385e-4435-aec8-3644665702a4" />
